### PR TITLE
修改当文本长度为零时crash的问题

### DIFF
--- a/TQRichTextView/TQRichTextView.m
+++ b/TQRichTextView/TQRichTextView.m
@@ -77,6 +77,10 @@
     {
         CFIndex testLineLength = CTTypesetterSuggestLineBreak(typeSetter,lineRange.location,self.bounds.size.width);
 check:  lineRange = CFRangeMake(lineRange.location,testLineLength);
+        // 防止crash
+        if (lineRange.length<0) {
+            return;
+        }
         CTLineRef line = CTTypesetterCreateLine(typeSetter,lineRange);
         CFArrayRef runs = CTLineGetGlyphRuns(line);
         


### PR DESCRIPTION
我是用的时候 集成到tableviewcell中时，会出现crash，所以加入此段代码
